### PR TITLE
Skip pinned NuGet package versions

### DIFF
--- a/org-inherited-config.json
+++ b/org-inherited-config.json
@@ -35,6 +35,12 @@
       "addLabels": [".NET"]
     },
     {
+      "description": ["Skip pinned NuGet package versions"],
+      "matchManagers": ["nuget"],
+      "matchCurrentValue": "^\\[[^,]+,\\)$",
+      "enabled": false
+    },
+    {
       "extends": ["monorepo:dotnet"],
       "description": ["Disable major version updates for .NET"],
       "matchUpdateTypes": ["major"],


### PR DESCRIPTION
Skip NuGet package versions "pinned" using `[x.y.z,)` syntax.
