### PR TITLE
Support updating runners

### DIFF
--- a/org-inherited-config.json
+++ b/org-inherited-config.json
@@ -4,6 +4,20 @@
   "automerge": false,
   "commitBodyTable": true,
   "commitMessageAction": "Bump",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": ["Update GitHub runner labels in workflow fields and matrix values"],
+      "managerFilePatterns": [
+        "/(^|/)(workflow-templates|\\.(?:github|gitea|forgejo)/(?:workflows|actions))/.+\\.ya?ml$/",
+        "/(^|/)action\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "# renovate:\\s*datasource=(?<datasource>github-runners)(?:\\s+[A-Za-z][A-Za-z0-9_-]*=[^\\s]+)*?(?:\\s+versioning=(?<versioning>[^\\s]+))?(?:\\s+[A-Za-z][A-Za-z0-9_-]*=[^\\s]+)*\\s*\\r?\\n\\s*(?:-\\s*)?(?:[A-Za-z0-9_-]+:\\s*)?['\"]?(?<depName>[a-zA-Z]+)-(?<currentValue>[A-Za-z0-9._-]+)['\"]?"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}github-runner{{/if}}"
+    }
+  ],
   "dependencyDashboard": false,
   "extends": [
     "config:best-practices",
@@ -55,6 +69,12 @@
       "description": ["Disable major version updates for .NET"],
       "matchUpdateTypes": ["major"],
       "enabled": false
+    },
+    {
+      "extends": ["monorepo:dotnet"],
+      "description": ["Cooldown on .NET updates to maximize batching"],
+      "matchManagers": ["nuget"],
+      "minimumReleaseAge": "1 day"
     }
   ],
   "requireConfig": "required",


### PR DESCRIPTION
- Add support for updating GitHub Actions runners not using `runs-on`.
- Try to maximise .NET update batching.
